### PR TITLE
Add disqus comment to `page` layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -314,7 +314,7 @@ enable_google_verification: false  # enables google site verification
 enable_bing_verification:   false  # enables bing site verification
 enable_masonry:             true   # enables automatic project cards arangement
 enable_math:                true   # enables math typesetting (uses MathJax)
-enable_tooltips:            false  # enables automatic tooltip links generated
+enable_tooltips:            true  # enables automatic tooltip links generated
                                    # for each section titles on pages and posts
 enable_darkmode:            true   # enables switching between light/dark modes
 enable_navbar_social:       true  # enables displaying social links in the

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,4 +13,19 @@ layout: default
             {{ content }}
           </article>
 
+          {%- if site.disqus_shortname and page.comments -%}
+            <div id="disqus_thread" style="max-width: {{ site.max_width }}; margin: 0 auto"></div>
+            <script type="text/javascript">
+              var disqus_shortname  = '{{ site.disqus_shortname }}';
+              var disqus_identifier = '{{ page.id }}';
+              var disqus_title      = {{ page.title | jsonify }};
+              (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+              })();
+            </script>
+            <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+          {%- endif %}
+
         </div>

--- a/_news/announcement_2.md
+++ b/_news/announcement_2.md
@@ -3,6 +3,7 @@ layout: post
 title: We published and presented a peer-reviewed paper in SCF21 conference!
 date: 2021-10-01 00:00:00-0400
 inline: false
+comments: true
 ---
 
 Our work, <em>"Topology Optimization via Frequency Tuning of Neural Design Representations"</em> was accepted, published, and I presented it at ACM Symposium on Computational Fabrication. This was my first-ever academic work which was part of my thesis at master's study.

--- a/_news/announcement_4.md
+++ b/_news/announcement_4.md
@@ -3,6 +3,7 @@ layout: post
 title: I gave a talk at Toronto Geometry Colloquium about my SCF21 publication.
 date: 2022-03-04 10:00:00-0400
 inline: false
+comments: true
 ---
 
 I gave a oral talk as the 10-min opener about <a href="{{site.baseurl}}/news/announcement_2">my recent publication</a> at <a href="toronto-geometry-colloquium.github.io">Toronto Geometry Colloquium</a> which is part of <a href="https://www.dgp.toronto.edu">Dynamic Graphics Project</a> lab at University of Toronto.

--- a/_projects/1_project.md
+++ b/_projects/1_project.md
@@ -5,6 +5,7 @@ description: What are the best routes a fleet of vehicles should take to reach a
 img: assets/img/mdvrp01.jpg
 importance: 1
 category: work
+comments: true
 ---
 
 Multi-Deport Vehicle Routing Problem (MDVRP) is a multi-objective optimization task. In MDVRP, the goal is to assign a number of vehicles which are distributed in multi depots in search for the customers meanwhile minimizing the number of vehicles used and distance traveled regarding some constraints such as vehicle weight threshold.

--- a/_projects/2_project.md
+++ b/_projects/2_project.md
@@ -5,6 +5,7 @@ description: Deep context-aware descreening and rescreening of halftone images i
 img: assets/img/de(re)screening01.jpg
 importance: 2
 category: work
+comments: true
 ---
 
 <div class="row">

--- a/_projects/3_project.md
+++ b/_projects/3_project.md
@@ -5,6 +5,7 @@ description: Tiny codes here and there that might be fun or hopefully useful
 img: assets/img/vhdl_game.gif
 importance: 3
 category: side-project
+comments: true
 ---
 
 <div class="row">


### PR DESCRIPTION
Well, previously, only `post` layout had the `disqus` comment which was only including `blog` and `news` section of site. The reason is that `news` and `blog` are using `post` layout. Due to this, `projects` section could not have comments. So I added the exact same feature from `post` layout to `page` layout. 

remark: this should have been done inside #10 PR